### PR TITLE
Bugfix/flash save session before redirect

### DIFF
--- a/middleware/request/validation/site.js
+++ b/middleware/request/validation/site.js
@@ -91,8 +91,10 @@ module.exports = (req, res, next) => {
 
   if (errors.length > 0) {
     req.flash('error', { msg: errors.join(',')});
-    const redirectUrl = getRefererUrl(req.header('Referer'));
-    return res.redirect(redirectUrl);
+    req.session.save( () => {
+      const redirectUrl = getRefererUrl(req.header('Referer'));
+      return res.redirect(redirectUrl);
+    });
   }
 
   next();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1184,20 +1184,6 @@
       "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.2.tgz",
       "integrity": "sha512-Ls2ylbo7++ITrWk2Yc3G/jijwSq5V3GT0tlgVXEl2kKYXY3ImrtmTCoE2uyTWFRI5owMBriloZFWbE1SXOsE7w=="
     },
-    "@types/webidl-conversions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
-      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
-    },
-    "@types/whatwg-url": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
-      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
-      "requires": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
-      }
-    },
     "@types/ws": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
@@ -3094,11 +3080,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
-    },
-    "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -5204,29 +5185,46 @@
       }
     },
     "mongodb": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.5.0.tgz",
-      "integrity": "sha512-A2l8MjEpKojnhbCM0MK3+UOGUSGvTNNSv7AkP1fsT7tkambrkkqN/5F2y+PhzsV0Nbv58u04TETpkaSEdI2zKA==",
+      "version": "2.2.36",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.36.tgz",
+      "integrity": "sha512-P2SBLQ8Z0PVx71ngoXwo12+FiSfbNfGOClAao03/bant5DgLNkOPAck5IaJcEk4gKlQhDEURzfR3xuBG1/B+IA==",
       "requires": {
-        "bson": "^4.6.2",
-        "denque": "^2.0.1",
-        "mongodb-connection-string-url": "^2.5.2",
-        "saslprep": "^1.0.3",
-        "socks": "^2.6.2"
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.20",
+        "readable-stream": "2.2.7"
       },
       "dependencies": {
-        "bson": {
-          "version": "4.6.2",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.2.tgz",
-          "integrity": "sha512-VeJKHShcu1b/ugl0QiujlVuBepab714X9nNyBdA1kfekuDGecxgpTA2Z6nYbagrWFeiIyzSWIOzju3lhj+RNyQ==",
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "readable-stream": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
           "requires": {
-            "buffer": "^5.6.0"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
-        "denque": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
-          "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         }
       }
     },
@@ -5283,36 +5281,19 @@
         }
       }
     },
-    "mongodb-connection-string-url": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.2.tgz",
-      "integrity": "sha512-tWDyIG8cQlI5k3skB6ywaEA5F9f5OntrKKsT/Lteub2zgwSUlhqEN2inGgBTm8bpYJf8QYBdA/5naz65XDpczA==",
+    "mongodb-core": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.20.tgz",
+      "integrity": "sha512-IN57CX5/Q1bhDq6ShAR6gIv4koFsZP7L8WOK1S0lR0pVDQaScffSMV5jxubLsmZ7J+UdqmykKw4r9hG3XQEGgQ==",
       "requires": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
+        "bson": "~1.0.4",
+        "require_optional": "~1.0.0"
       },
       "dependencies": {
-        "tr46": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-          "requires": {
-            "punycode": "^2.1.1"
-          }
-        },
-        "webidl-conversions": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
-        },
-        "whatwg-url": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-          "requires": {
-            "tr46": "^3.0.0",
-            "webidl-conversions": "^7.0.0"
-          }
+        "bson": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+          "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
         }
       }
     },
@@ -7725,20 +7706,6 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.5.3.tgz",
       "integrity": "sha512-/HkjRdwPY3yHJReXu38NiusZw2+LLE2SrhkWJtmlPDB1fqFSvioYj62NkPcrKiNCgRLeGcGK7QBvr1iQwybeXw=="
-    },
-    "smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
-    },
-    "socks": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
-      "requires": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.2.0"
-      }
     },
     "source-map": {
       "version": "0.6.1",

--- a/routes/server.js
+++ b/routes/server.js
@@ -29,7 +29,9 @@ module.exports = function(app){
       const ingresses = await ingress.ensureIngressForAllDomains(req.sites);
 
       req.flash('success', { msg: 'Checked ingress' });
-      res.redirect('/admin/server');
+      req.session.save( () => {
+        res.redirect('/admin/server');
+      });
     }
   );
 

--- a/routes/site/idea-export.js
+++ b/routes/site/idea-export.js
@@ -18,7 +18,9 @@ module.exports = function(app){
     (req, res, next) => {
       if (req.ideas.length === 0) {
         req.flash('error', { msg: 'No ideas to export'});
-        res.redirect(req.header('Referer'));
+        req.session.save( () => {
+          res.redirect(req.header('Referer'));
+        });
       } else {
         const exportHeaders = [
           {key: 'id', label: 'ID'},

--- a/routes/site/idea-import.js
+++ b/routes/site/idea-import.js
@@ -65,14 +65,18 @@ module.exports = function(app){
       Promise.all(promises)
         .then(function (response) {
           req.flash('success', { msg: 'Geimporteerd!'});
-          res.redirect(`/admin/site/${req.params.siteId}/ideas`);
-    //      res.redirect(redirectTo);
+          req.session.save( () => {
+            res.redirect(`/admin/site/${req.params.siteId}/ideas`);
+            //      res.redirect(redirectTo);
+          });
         })
         .catch(function (err) {
           console.log('errerrerrerr', err);
           let message = err && err.error && err.error.message ?  'Er gaat iets mis: '+ err.error.message : 'Er gaat iets mis!';
           req.flash('error', { msg: message});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         });
     }
   );

--- a/routes/site/idea.js
+++ b/routes/site/idea.js
@@ -80,8 +80,10 @@ module.exports = function(app){
         })
         .catch(function (err) {
            let message = err && err.error && err.error.message ?  'Er gaat iets mis: '+ err.error.message : 'Er gaat iets mis!';
-           req.flash('error', { msg: message});
-           res.redirect(req.header('Referer')  || appUrl);
+          req.flash('error', { msg: message});
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         });
     }
   );
@@ -133,14 +135,18 @@ module.exports = function(app){
       ideaApi
         .create(req.session.jwt, req.params.siteId, idea)
         .then(function (response) {
-           req.flash('success', { msg: 'Aangemaakt!'});
-           res.redirect(`/admin/site/${req.params.siteId}/ideas`);
-           res.redirect(redirectTo);
+          req.flash('success', { msg: 'Aangemaakt!'});
+          req.session.save( () => {
+            res.redirect(`/admin/site/${req.params.siteId}/ideas`);
+            res.redirect(redirectTo);
+          });
         })
         .catch(function (err) {
           let message = err && err.error && err.error.message ?  'Er gaat iets mis: '+ err.error.message : 'Er gaat iets mis!';
           req.flash('error', { msg: message});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         });
     }
   );

--- a/routes/site/newsletter.js
+++ b/routes/site/newsletter.js
@@ -69,7 +69,9 @@ module.exports = function(app){
     (req, res, next) => {
       if (req.newsletterSubsribers.length === 0) {
         req.flash('error', { msg: 'No subscribers to export'});
-        res.redirect(req.header('Referer'));
+        req.session.save( () => {
+          res.redirect(req.header('Referer'));
+        });
       } else {
         const exportHeaders = [
           {key: 'id', label: 'ID'},

--- a/routes/site/site.js
+++ b/routes/site/site.js
@@ -209,12 +209,16 @@ module.exports = function(app){
           }
 
           req.flash('success', { msg: 'De site is succesvol aangemaakt'});
-        res.redirect('/admin/site/' + site.id)
+          req.session.save( () => {
+              res.redirect('/admin/site/' + site.id)
+          });
 
       } catch (error) {
         console.error(error);
         req.flash('error', { msg: 'Het is helaas niet gelukt om de site aan te maken.'});
-        res.redirect('back');
+        req.session.save( () => {
+          res.redirect('back');
+        });
       }
     }
   );
@@ -265,11 +269,15 @@ module.exports = function(app){
           }
 
         req.flash('success', { msg: 'De site is succesvol aangemaakt'});
-        res.redirect('/admin/site/' + site.id);
+        req.session.save( () => {
+          res.redirect('/admin/site/' + site.id);
+        });
       } catch(error) {
         console.error(error);
         req.flash('error', { msg: 'Het is helaas niet gelukt om de site aan te maken'});
-        res.redirect('back');
+        req.session.save( () => {
+          res.redirect('back');
+        });
       }
     },
   );
@@ -325,7 +333,9 @@ module.exports = function(app){
         console.log('SITE EXPORT FAILED');
         console.log(err);
         req.flash('error', { msg: 'Het is helaas niet gelukt om de site te exporteren'});
-        res.redirect('back');
+        req.session.save( () => {
+          res.redirect('back');
+        });
       }
 
     }
@@ -403,7 +413,9 @@ module.exports = function(app){
 
           await k8Ingress.ensureIngressForAllDomains(req.sites)
 
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         })
         .catch((err) => { next(err) });
     }
@@ -474,12 +486,16 @@ module.exports = function(app){
 
 
           req.flash('success', { msg: 'Url aangepast!'});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         })
         .catch(function (err) {
           console.error(err);
           req.flash('error', { msg: 'Er gaat iets mis!'});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         });
 
     }
@@ -515,12 +531,16 @@ module.exports = function(app){
       Promise.all(promises)
         .then(function (response) {
           req.flash('success', { msg: 'Aangepast!'});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         })
         .catch(function (err) {
           console.error(err);
           req.flash('error', { msg: 'Er gaat iets mis!'});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         });
 
     }
@@ -542,14 +562,18 @@ module.exports = function(app){
       Promise.all(anonymizeActions)
         .then((response) => {
           req.flash('success', { msg: 'Geannonimiseerd!'});
-          res.redirect('/admin');
+          req.session.save( () => {
+            res.redirect('/admin');
+          });
         })
         .catch((err) => {
           console.log('ANONYMIZE WEBSITE FAILED');
           console.log(err);
           let message = err && err.error && err.error.message ?  'Er gaat iets mis: '+ err.error.message : 'Er gaat iets mis!';
           req.flash('error', { msg: message});
-          res.redirect('/admin');
+          req.session.save( () => {
+            res.redirect('/admin');
+          });
         });
     }
   );
@@ -584,14 +608,18 @@ module.exports = function(app){
         })
         .then( result => {
           req.flash('success', { msg: 'Verwijderd!'});
-          res.redirect('/admin');
+          req.session.save( () => {
+            res.redirect('/admin');
+          });
         })
         .catch( err => {
           console.log('DELETE WEBSITE FAILED');
           console.log(err);
           let message = err && err.error && err.error.message ?  'Er gaat iets mis: '+ err.error.message : 'Er gaat iets mis!';
           req.flash('error', { msg: message});
-          res.redirect('/admin');
+          req.session.save( () => {
+            res.redirect('/admin');
+          });
         });
     }
   );

--- a/routes/site/uniqueCode.js
+++ b/routes/site/uniqueCode.js
@@ -63,7 +63,9 @@ module.exports = function(app){
       if (amountOfCodes > maxCodesAllowed) {
         let message = 'Je kunt niet meer dan ' + maxCodesAllowed + ' codes in één keer aanmaken';
         req.flash('error', { msg: message});
-        return res.redirect(req.header('Referer')  || appUrl);
+        req.session.save( () => {
+          return res.redirect(req.header('Referer')  || appUrl);
+        });
       }
       
       // create codes in the background
@@ -78,13 +80,17 @@ module.exports = function(app){
         })
         .then(function (response) {
           req.flash('success', { msg: 'Codes worden aangemaakt!'});
-          res.redirect('/admin/site/'+req.site.id+'/unique-codes'  || appUrl);
+          req.session.save( () => {
+            res.redirect('/admin/site/'+req.site.id+'/unique-codes'  || appUrl);
+          });
         })
         .catch(function (err) {
           console.log('Create bulk codes error:', err);
           let message = err && err.error && err.error.message ?  'Er gaat iets mis: '+ err.error.message : 'Er gaat iets mis!';
           req.flash('error', { msg: message});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         });
     }
   );
@@ -121,12 +127,16 @@ module.exports = function(app){
         .delete(req.params.uniqueCodeId)
         .then(() => {
           req.flash('success', { msg: 'Verwijderd!'});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         })
         .catch((err) => {
           let message = err && err.error && err.error.message ?  'Er gaat iets mis: '+ err.error.message : 'Er gaat iets mis!';
           req.flash('error', { msg: message});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         });
     }
   );
@@ -142,12 +152,16 @@ module.exports = function(app){
         .reset(req.params.uniqueCodeId)
         .then(() => {
           req.flash('success', { msg: 'Verwijderd!'});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         })
         .catch((err) => {
           let message = err && err.error && err.error.message ?  'Er gaat iets mis: '+ err.error.message : 'Er gaat iets mis!';
           req.flash('error', { msg: message});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         });
     }
   );

--- a/routes/site/user-api.js
+++ b/routes/site/user-api.js
@@ -37,12 +37,16 @@ module.exports = function(app) {
 
       if (!req.body.authTypes) {
         req.flash('error', { msg: 'At least one authentication method is required'});
-        res.redirect(req.header('Referer')  || appUrl);
+        req.session.save( () => {
+          res.redirect(req.header('Referer')  || appUrl);
+        });
 
       // only allow emailRequired if email is validated through an auth type like email url of password
       } else if (emailRequired && !emailAuthTypesEnabled) {
         req.flash('error', { msg: 'Select an authentication method that uses e-mail if you want to make e-mail an required field.'});
-        res.redirect(req.header('Referer')  || appUrl);
+        req.session.save( () => {
+          res.redirect(req.header('Referer')  || appUrl);
+        });
       } else {
         data.requiredUserFields = req.body.requiredUserFields ? req.body.requiredUserFields : [];
         data.authTypes = req.body.authTypes;
@@ -52,7 +56,9 @@ module.exports = function(app) {
           .update(req.userApiClient.clientId, data)
           .then((userClient) => {
             req.flash('success', { msg: 'Aangepast!'});
-            res.redirect(req.header('Referer')  || appUrl);
+            req.session.save( () => {
+              res.redirect(req.header('Referer')  || appUrl);
+            });
           })
           .catch((err) => { next(err) });
       }
@@ -103,7 +109,9 @@ module.exports = function(app) {
         .update(req.userApiClient.clientId, data)
         .then((userClient) => {
           req.flash('success', { msg: 'Aangepast!'});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         })
         .catch((err) => { next(err) });
     }
@@ -141,12 +149,16 @@ module.exports = function(app) {
         .all(updateActions)
         .then(() => {
           req.flash('success', { msg: 'Updated!'});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         })
         .catch((err) => {
           console.log('->>> E:', err.message)
           req.flash('success', { msg: 'Something went wrong!'});
-          res.redirect(req.header('Referer')  || appUrl);
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+          });
         })
 
     }

--- a/routes/site/votes.js
+++ b/routes/site/votes.js
@@ -42,13 +42,17 @@ module.exports = function(app) {
       rp(options)
         .then(function (votes) {
           req.flash('success', { msg: 'Updated!'});
-          res.redirect(req.header('Referer')  || appUrl);
-           next();
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+            next();
+          });
         })
         .catch(function (err) {
           req.flash('error', { msg: 'Something whent wrong!'});
-          res.redirect(req.header('Referer')  || appUrl);
-          next();
+          req.session.save( () => {
+            res.redirect(req.header('Referer')  || appUrl);
+            next();
+          });
         });
   });
 }

--- a/routes/user.js
+++ b/routes/user.js
@@ -108,12 +108,16 @@ module.exports = function(app){
         .create(req.body)
         .then((response) => {
           req.flash('success', { msg: 'Created user!' });
-          res.redirect('/admin/users');
+          req.session.save( () => {
+            res.redirect('/admin/users');
+          });
         })
         .catch((err) => {
           let message = err && err.error && err.error.message ?  'Er gaat iets mis: '+ err.error.message : 'Er gaat iets mis!';
           req.flash('error', { msg: message });
-          res.redirect('/admin/user');
+          req.session.save( () => {
+            res.redirect('/admin/user');
+          });
         })
     }
   );
@@ -136,12 +140,16 @@ module.exports = function(app){
         .update(req.params.userId, req.body)
         .then((response) => {
           req.flash('success', { msg: 'Updated user!' });
-          res.redirect('/admin/user/' + req.params.userId);
+          req.session.save( () => {
+            res.redirect('/admin/user/' + req.params.userId);
+          });
         })
         .catch((err) => {
           let message = err && err.error && err.error.message ?  'Er gaat iets mis: '+ err.error.message : 'Er gaat iets mis!';
           req.flash('error', { msg: message });
-          res.redirect('/admin/user/' + req.params.userId);
+          req.session.save( () => {
+            res.redirect('/admin/user/' + req.params.userId);
+          });
         })
     }
   );
@@ -155,12 +163,16 @@ module.exports = function(app){
         .delete(req.params.userId)
         .then((response) => {
           req.flash('success', { msg: 'Deleted user!' });
-          res.redirect('/admin/users');
+          req.session.save( () => {
+            res.redirect('/admin/users');
+          });
         })
         .catch((err) => {
           let message = err && err.error && err.error.message ?  'Er gaat iets mis: '+ err.error.message : 'Er gaat iets mis!';
           req.flash('error', { msg: message });
-          res.redirect('/admin/users');
+          req.session.save( () => {
+            res.redirect('/admin/users');
+          });
         })
     }
   );


### PR DESCRIPTION
# Description

express-flash messages are not always saved before a page is redirected. If the redirect happens before the session is saved a flash message is not shown.

Some e2e tests require the message to be shown.

Fix this by adding a explicit req.session.save before the redirect.

## Issue reference

Fixes e2e tests errors
See also https://github.com/RGBboy/express-flash/issues/13
and https://github.com/jaredhanson/connect-flash/issues/23

## Type of change

Bug fix

## Documentation

N/A

## Tests

Locally and on AMS staging
