### PR TITLE
Fixed setting the new title on site copy based on development

### DIFF
--- a/providers/cmsProvider.js
+++ b/providers/cmsProvider.js
@@ -204,6 +204,16 @@ const uploadAttachments = async ({ targetUrl, attachmentsDir, attachments }) => 
 
 };
 
+/**
+ * Rename the siteTitle field of the imported site and update it in the database
+ * 
+ * @param newSite
+ * @param mongoPath
+ */
+ const renameSiteTitleInDatabase = async (newSite) => {
+  console.log(`renaming the site title to ${newSite.title}`);
+  return mongoService.editSiteTitle(newSite.title, newSite.getCmsDatabaseName(), "aposDocs");
+};
 
 module.exports = exports = {
   generateId,
@@ -212,4 +222,5 @@ module.exports = exports = {
   importCmsDatabase,
   renameAttachments,
   uploadAttachments,
+  renameSiteTitleInDatabase,
 }

--- a/services/mongo.js
+++ b/services/mongo.js
@@ -139,3 +139,15 @@ exports.import = (dbName, dirname) => {
 
   });
 }
+
+exports.editSiteTitle = (siteTitle, dbName, collectionName) => {
+  return new Promise((resolve, reject) => {
+    MongoClient.connect(url, function(err, db) {
+      if (err) return reject(err);
+        var dbo = db.db(dbName);
+        dbo.collection(collectionName).updateMany({type: {$regex : /global/}}, {$set: {siteTitle}});
+        db.close();
+        resolve();
+    });
+  });
+}

--- a/services/openstad/openstadSiteDataService.js
+++ b/services/openstad/openstadSiteDataService.js
@@ -222,8 +222,8 @@ exports.createSite = async ({ user, dataDir, newSite, apiData, cmsData, oauthDat
 
     const oauthClients = await oauthProvider.createOauth(newSite, oauthData.clients);
     await cmsProvider.importCmsDatabase(newSite, cmsData.mongoPath);
-
     const site = await apiProvider.createSite(newSite, apiData.site, oauthClients);
+    await cmsProvider.renameSiteTitleInDatabase(newSite);
 
     if (apiData.choiceGuides) {
       await apiProvider.createChoiceGuides(site.id, apiData.choiceGuides);


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description
Created function to change the name of the siteTitle of the created site to the new name, overwriting the old copied name.

## Type of change
bug fix

## Tests
In the admin panel of openstad copy a site and give it a new name. The name should be visible in the title when opening the website (both in page and in the tab)