### PR TITLE
fix: removing system ingresses

### DIFF
--- a/services/k8/ingress.js
+++ b/services/k8/ingress.js
@@ -348,7 +348,18 @@ exports.ensureIngressForAllDomains = async () => {
 
   const ingressPrefix = (process.env.KUBERNETES_NAMESPACE ? process.env.KUBERNETES_NAMESPACE : 'openstad');
   
-  const systemIngresses = [`${ingressPrefix}-admin`, `${ingressPrefix}-frontend`, `${ingressPrefix}-image`, `${ingressPrefix}-api`, `${ingressPrefix}-auth`];
+  const systemIngresses = [
+    `${ingressPrefix}-admin`,
+    `${ingressPrefix}-frontend`,
+    `${ingressPrefix}-image`,
+    `${ingressPrefix}-api`,
+    `${ingressPrefix}-auth`,
+    `openstad-admin`,
+    `openstad-frontend`,
+    `openstad-image`,
+    `openstad-api`,
+    `openstad-auth`,
+  ];
 
   // filter all domains present
   let domainsToDelete = Object.keys(domainsInIngress).filter((domainInIngress) => {


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description

This should fix a problem where system ingresses where removed when the kubernetes namespace and release name where not identical. 

## Type of change

bugfix
