### PR TITLE
Fix: add `CDN_DIST_TAG` env to fetch latest dist tag of react-admin

### DIFF
--- a/services/cdns.js
+++ b/services/cdns.js
@@ -19,17 +19,17 @@ exports.contructReactAdminCdn = async function () {
       if (!version) {
         // fallback
         let packageFile =
-          fs.readFileSync(`${__dirname}/package.json`).toString() || '';
+          await fs.readFile(`${__dirname}/../package.json`).toString() || '';
         let match =
           packageFile &&
           packageFile.match(
             /"openstad-react-openstadComponentsCdn":\s*"(?:[^"\d]*)((?:\d+\.)*\d+)"/
           );
-        version = (match && match[1]) || null;
+        version = (match && match[1]) || '';
       }
       openstadReactAdminCdn = openstadReactAdminCdn.replace(
-        '{version}',
-        version
+        '@{version}',
+        version ? `@${version}` : ''
       );
     } catch (err) {
       console.log('Error constructing cdn url', err);

--- a/services/cdns.js
+++ b/services/cdns.js
@@ -1,38 +1,61 @@
-exports.contructReactAdminCdn = async function() {
+const fs = require('fs').promises;
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
 
+exports.contructReactAdminCdn = async function () {
   // construct cdn urls
-  let openstadReactAdminCdn = process.env.OPENSTAD_REACT_ADMIN_CDN || 'https://cdn.jsdelivr.net/npm/openstad-react-admin@{version}/dist';
+  let openstadReactAdminCdn =
+    process.env.OPENSTAD_REACT_ADMIN_CDN ||
+    'https://cdn.jsdelivr.net/npm/openstad-react-admin@{version}/dist';
   if (openstadReactAdminCdn.match('{version}')) {
-
     try {
-      const fs = require('fs').promises;
-      const util = require('util');
-      const exec = util.promisify(require('child_process').exec);
-      
-      let { stdout, stderr } = await exec('git rev-parse --abbrev-ref HEAD');
-      let branch = stdout && stdout.toString();
-      branch = branch.trim();
+      let tag = await getTag();
 
-      let tag = 'alpha';
-      if (branch == 'release') tag = 'beta';
-      if (branch == 'master') tag = 'latest';
-      
       // get current published version
       ({ stdout, stderr } = await exec('npm view --json openstad-react-admin'));
       let info = stdout && stdout.toString();
-      info = JSON.parse(info)
+      info = JSON.parse(info);
       let version = info['dist-tags'][tag];
       if (!version) {
         // fallback
-        let packageFile = fs.readFileSync(`${__dirname}/package.json`).toString() || '';
-        let match = packageFile && packageFile.match(/"openstad-react-openstadComponentsCdn":\s*"(?:[^"\d]*)((?:\d+\.)*\d+)"/);
-        version = match && match[1] || null;
+        let packageFile =
+          fs.readFileSync(`${__dirname}/package.json`).toString() || '';
+        let match =
+          packageFile &&
+          packageFile.match(
+            /"openstad-react-openstadComponentsCdn":\s*"(?:[^"\d]*)((?:\d+\.)*\d+)"/
+          );
+        version = (match && match[1]) || null;
       }
-      openstadReactAdminCdn = openstadReactAdminCdn.replace('{version}', version);
-    } catch (err) {console.log('Error constructing cdn url', err);}
-
+      openstadReactAdminCdn = openstadReactAdminCdn.replace(
+        '{version}',
+        version
+      );
+    } catch (err) {
+      console.log('Error constructing cdn url', err);
+    }
   }
 
   return openstadReactAdminCdn;
-  
+};
+
+async function getTag() {
+  let branch = '';
+  let tag = 'alpha';
+
+  try {
+    let { stdout, stderr } = await exec('git rev-parse --abbrev-ref HEAD');
+    branch = stdout && stdout.toString().trim();
+  } catch (error) {
+    // As a fallback we check for the CDN_DIST_TAG env variable
+    if (process.env.CDN_DIST_TAG) {
+      tag = process.env.CDN_DIST_TAG;
+    }
+    console.warn(`Could not get branch via git; fallback to ${tag}`);
+  }
+
+  if (branch == 'release') tag = 'beta';
+  if (branch == 'master') tag = 'latest';
+
+  return tag;
 }


### PR DESCRIPTION
See https://github.com/openstad/openstad-frontend/pull/390