### PR TITLE
fix: use new ingressClassName instead of annotation

### DIFF
--- a/services/k8/ingress.js
+++ b/services/k8/ingress.js
@@ -171,7 +171,6 @@ const getIngressBody = (ingressName, domain, addWww, secretName) => {
       },
       name: ingressName,
       annotations: {
-        'kubernetes.io/ingress.class': 'nginx',
         'nginx.ingress.kubernetes.io/from-to-www-redirect': "true",
         'nginx.ingress.kubernetes.io/proxy-body-size': '128m',
         'nginx.ingress.kubernetes.io/configuration-snippet': `more_set_headers "X-Content-Type-Options: nosniff";
@@ -181,6 +180,7 @@ more_set_headers "Referrer-Policy: same-origin";`
       }
     },
     spec: {
+      ingressClassName: 'nginx',
       rules: [{
         host: domain,
         http: {


### PR DESCRIPTION
# Description

Since k8s 1.19 the ingress has a new property called `ingressClassName`. This replaces the annotation previously used.

## Issue reference

Fixes k8s errors creating ingresses

## Type of change

bug fix; might be breaking on older k8s clusters
