### PR TITLE
feat: skip dns check

### DIFF
--- a/services/k8/ingress.js
+++ b/services/k8/ingress.js
@@ -431,17 +431,25 @@ exports.ensureIngressForAllDomains = async () => {
 const processIngressForDomain = async (domain, sites, ingressName) => {
   console.log('start processIngressForDomain');
 
+  const skipDNSCheck = process.env.SKIP_DNS_CHECK === 'true';
+
   const sitesForDomain = getSitesForDomain(sites, domain);
   const addWww = shouldDomainHaveWww(sites, domain);
 
   let ipAddressForDomain;
   let ipAddressForWWWDomain;
 
-  try {
-    ipAddressForDomain = await dnsLookUp(domain);
-    ipAddressForWWWDomain = await dnsLookUp('www.' + domain);
-  } catch(e ) {
-    console.log('Error checking dns for domain', domain);
+  if (skipDNSCheck === false) {
+    try {
+      ipAddressForDomain = await dnsLookUp(domain);
+      ipAddressForWWWDomain = await dnsLookUp('www.' + domain);
+    } catch(e ) {
+      console.log('Error checking dns for domain', domain);
+    }
+  } else {
+    console.log('Skip DNS check')
+    ipAddressForDomain = serverPublicIP
+    ipAddressForWWWDomain = serverPublicIP
   }
 
   const dnsIsSet = ipAddressForDomain && ipAddressForDomain === serverPublicIP;


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description

This allows admin server to create ingresses even if the DNS isn't pointing to the domain. By setting the `SKIP_DNS_CHECK` environment variable to `true`.

## Type of change

Feature
